### PR TITLE
Removed PHP 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
     - 7.0


### PR DESCRIPTION
Framework/CMS now require PHP 5.5 to install.